### PR TITLE
post url if media_type is video

### DIFF
--- a/src/commands/apodCommand.ts
+++ b/src/commands/apodCommand.ts
@@ -63,7 +63,7 @@ export class APODCommand extends AbstractAPICommand {
     return [
       `${response.title} ${copyright}`,
       response.explanation,
-      response.media_type == 'video' ? response.url : response.hdurl,
+      response.media_type == "video" ? response.url : response.hdurl,
     ].join("\n");
   }
 }

--- a/src/commands/apodCommand.ts
+++ b/src/commands/apodCommand.ts
@@ -63,7 +63,7 @@ export class APODCommand extends AbstractAPICommand {
     return [
       `${response.title} ${copyright}`,
       response.explanation,
-      response.hdurl,
+      response.media_type == 'video' ? response.url : response.hdurl,
     ].join("\n");
   }
 }

--- a/src/commands/apodCommand.ts
+++ b/src/commands/apodCommand.ts
@@ -63,7 +63,7 @@ export class APODCommand extends AbstractAPICommand {
     return [
       `${response.title} ${copyright}`,
       response.explanation,
-      response.media_type == "video" ? response.url : response.hdurl,
+      response.media_type === "video" ? response.url : response.hdurl,
     ].join("\n");
   }
 }


### PR DESCRIPTION
If media_type is "video", hdurl is not present, so url should be used instead.